### PR TITLE
Implement minimal Go IRC server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-vibes.
+# Vibes IRC Server
+
+This repository contains a minimal IRC server implementation written in Go.
+
+## Usage
+
+```
+go run ./server
+```
+
+The server listens on TCP port `6667` by default.
+
+## Running Tests
+
+```
+go test ./...
+```
+
+## Manual Testing
+
+To try the server manually, run it in one terminal and connect using `nc` in
+another:
+
+```bash
+go run ./server
+```
+
+Then, from a separate shell:
+
+```bash
+nc 127.0.0.1 6667
+```
+
+Interact with the server using standard IRC commands. For example:
+
+```
+NICK tester
+USER tester 0 * :Real Name
+JOIN #general
+PRIVMSG #general :hello world
+```

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,4 @@
+module vibes
+
+go 1.20
+

--- a/server/main.go
+++ b/server/main.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"net"
+	"strings"
+	"sync"
+)
+
+// Client represents a connected IRC client.
+type Client struct {
+	conn     net.Conn
+	nickname string
+	username string
+	channels map[string]bool
+}
+
+// Server maintains IRC state.
+type Server struct {
+	addr     string
+	mu       sync.Mutex
+	clients  map[net.Conn]*Client
+	channels map[string]map[*Client]bool
+}
+
+// NewServer creates a new IRC server.
+func NewServer(addr string) *Server {
+	return &Server{
+		addr:     addr,
+		clients:  make(map[net.Conn]*Client),
+		channels: make(map[string]map[*Client]bool),
+	}
+}
+
+func (s *Server) run() error {
+	ln, err := net.Listen("tcp", s.addr)
+	if err != nil {
+		return err
+	}
+	log.Printf("IRC server listening on %s", s.addr)
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			log.Println("accept error:", err)
+			continue
+		}
+		go s.handleConn(conn)
+	}
+}
+
+func (s *Server) handleConn(conn net.Conn) {
+	client := &Client{conn: conn, channels: make(map[string]bool)}
+	s.mu.Lock()
+	s.clients[conn] = client
+	s.mu.Unlock()
+
+	defer func() {
+		s.mu.Lock()
+		delete(s.clients, conn)
+		s.mu.Unlock()
+		conn.Close()
+	}()
+
+	reader := bufio.NewScanner(conn)
+	for reader.Scan() {
+		line := reader.Text()
+		s.handleLine(client, line)
+	}
+}
+
+func (s *Server) handleLine(c *Client, line string) {
+	parts := strings.SplitN(line, " ", 2)
+	cmd := strings.ToUpper(parts[0])
+	arg := ""
+	if len(parts) > 1 {
+		arg = parts[1]
+	}
+	switch cmd {
+	case "NICK":
+		c.nickname = arg
+	case "USER":
+		c.username = arg
+	case "PING":
+		c.conn.Write([]byte("PONG :" + arg + "\r\n"))
+	case "JOIN":
+		s.joinChannel(c, arg)
+	case "PRIVMSG":
+		s.handlePrivMsg(c, arg)
+	case "QUIT":
+		c.conn.Close()
+	}
+}
+
+func (s *Server) joinChannel(c *Client, name string) {
+	s.mu.Lock()
+	ch, ok := s.channels[name]
+	if !ok {
+		ch = make(map[*Client]bool)
+		s.channels[name] = ch
+	}
+	ch[c] = true
+	c.channels[name] = true
+	s.mu.Unlock()
+	s.broadcast(ch, fmt.Sprintf(":%s JOIN %s\r\n", c.nickname, name))
+}
+
+func (s *Server) handlePrivMsg(c *Client, msg string) {
+	parts := strings.SplitN(msg, " ", 2)
+	if len(parts) != 2 {
+		return
+	}
+	target, body := parts[0], parts[1]
+	if strings.HasPrefix(body, ":") {
+		body = body[1:]
+	}
+	if strings.HasPrefix(target, "#") {
+		s.mu.Lock()
+		ch := s.channels[target]
+		s.mu.Unlock()
+		s.broadcast(ch, fmt.Sprintf(
+			":%s PRIVMSG %s :%s\r\n",
+			c.nickname,
+			target,
+			body,
+		))
+	} else {
+		s.mu.Lock()
+		for client := range s.clients {
+			if s.clients[client].nickname == target {
+				client.Write([]byte(fmt.Sprintf(
+					":%s PRIVMSG %s :%s\r\n",
+					c.nickname,
+					target,
+					body,
+				)))
+				break
+			}
+		}
+		s.mu.Unlock()
+	}
+}
+
+func (s *Server) broadcast(clients map[*Client]bool, msg string) {
+	for c := range clients {
+		c.conn.Write([]byte(msg))
+	}
+}
+
+func main() {
+	addr := ":6667"
+	s := NewServer(addr)
+	if err := s.run(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"net"
+	"testing"
+)
+
+func TestNewServer(t *testing.T) {
+	s := NewServer(":6667")
+	if s.addr != ":6667" {
+		t.Errorf("expected addr to be :6667, got %s", s.addr)
+	}
+	if s.clients == nil || s.channels == nil {
+		t.Error("expected maps to be initialized")
+	}
+}
+
+func TestBroadcast(t *testing.T) {
+	s := NewServer(":0")
+	client := &Client{}
+	conn1, conn2 := net.Pipe()
+	client.conn = conn1
+	ch := map[*Client]bool{client: true}
+
+	go s.broadcast(ch, "test\r\n")
+
+	buf := make([]byte, 6)
+	if _, err := conn2.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+	if string(buf) != "test\r\n" {
+		t.Errorf("expected message 'test\\r\\n', got %q", string(buf))
+	}
+}


### PR DESCRIPTION
## Summary
- add a simple IRC server with basic join, privmsg, and ping commands
- create tests for server creation and broadcasting
- add module definition
- update README with usage instructions and manual testing steps

## Testing
- `go test ./...`
