### PR TITLE
Improve IRC logging and docs

### DIFF
--- a/project/irc/README.md
+++ b/project/irc/README.md
@@ -19,3 +19,32 @@ Change into the `project/irc` directory and run:
 ```
 go test ./...
 ```
+
+## Manual Testing
+
+You can exercise the server manually using `telnet` or `nc`:
+
+1. Start the server:
+
+   ```
+   go run ./project/irc/server
+   ```
+
+2. In another terminal connect to the server:
+
+   ```
+   nc localhost 6667
+   ```
+
+3. Issue some basic IRC commands:
+
+   ```
+   NICK alice
+   USER alice 0 * :Alice
+   JOIN #chat
+   PRIVMSG #chat :hello there!
+   QUIT
+   ```
+
+The server will write connection and channel activity to `server.log` while
+errors continue to appear on stderr.


### PR DESCRIPTION
## Summary
- document how to run manual tests for the IRC server
- log client connections, disconnects and channel events
- write logs to `server.log` while still printing errors to stderr

## Testing
- `go test ./...`