### PR TITLE
Combine Nick and User into Login

### DIFF
--- a/project/irc/client/client.go
+++ b/project/irc/client/client.go
@@ -21,14 +21,15 @@ func Connect(addr string) (*Client, error) {
 	return &Client{conn: conn, r: bufio.NewReader(conn)}, nil
 }
 
-// Nick sends the NICK command.
-func (c *Client) Nick(name string) error {
-	return c.sendf("NICK %s", name)
-}
-
-// User sends the USER command.
-func (c *Client) User(user string) error {
-	return c.sendf("USER %s", user)
+// Login sends the NICK and USER commands using the same value.
+// IRC servers typically require both commands during connection
+// setup but in this client the values are always identical.  Login
+// combines the two so callers don't have to issue them separately.
+func (c *Client) Login(name string) error {
+	if err := c.sendf("NICK %s", name); err != nil {
+		return err
+	}
+	return c.sendf("USER %s", name)
 }
 
 // Join joins the given channel.

--- a/project/irc/example/main.go
+++ b/project/irc/example/main.go
@@ -29,8 +29,7 @@ func main() {
 	}
 	defer cli.Close()
 
-	cli.Nick("tester")
-	cli.User("tester")
+	cli.Login("tester")
 	cli.Join("#chat")
 	cli.Msg("#chat", "hello world")
 

--- a/project/irc/irc/integration_test.go
+++ b/project/irc/irc/integration_test.go
@@ -26,14 +26,12 @@ func TestClientFlow(t *testing.T) {
 	}
 	defer c2.Close()
 
-	if err := c1.Nick("alice"); err != nil {
+	if err := c1.Login("alice"); err != nil {
 		t.Fatal(err)
 	}
-	c1.User("alice")
-	if err := c2.Nick("bob"); err != nil {
+	if err := c2.Login("bob"); err != nil {
 		t.Fatal(err)
 	}
-	c2.User("bob")
 
 	c1.Join("#room")
 	c2.Join("#room")


### PR DESCRIPTION
## Summary
- streamline client API by combining Nick and User commands into `Login`
- update integration test and example to use the new `Login` method

## Testing
- `go test ./...`