### PR TITLE
Fix server close handling

### DIFF
--- a/project/irc/irc/server.go
+++ b/project/irc/irc/server.go
@@ -2,6 +2,7 @@ package irc
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -52,7 +53,7 @@ func (s *Server) Run() error {
 	for {
 		conn, err := ln.Accept()
 		if err != nil {
-			if strings.Contains(err.Error(), "closed") {
+			if errors.Is(err, net.ErrClosed) {
 				return nil
 			}
 			ErrorLogger.Println("accept error:", err)


### PR DESCRIPTION
## Summary
- improve the error check in `Server.Run` when the listener is closed

## Testing
- `go test ./...`