### PR TITLE
Add listener ready signal to IRC server

### DIFF
--- a/project/irc/example/main.go
+++ b/project/irc/example/main.go
@@ -14,14 +14,15 @@ func main() {
 	irc.ErrorLogger = irc.Logger
 
 	srv := irc.NewServer(":6667")
+	ready := make(chan struct{})
 	go func() {
-		if err := srv.Run(); err != nil {
+		if err := srv.Run(ready); err != nil {
 			irc.ErrorLogger.Fatal(err)
 		}
 	}()
 
-	// Give the server a moment to start
-	time.Sleep(100 * time.Millisecond)
+	// Wait for the server to start
+	<-ready
 
 	cli, err := client.Connect("localhost:6667")
 	if err != nil {

--- a/project/irc/irc/integration_test.go
+++ b/project/irc/irc/integration_test.go
@@ -3,16 +3,16 @@ package irc
 import (
 	"strings"
 	"testing"
-	"time"
 
 	ic "vibes/client"
 )
 
 func TestClientFlow(t *testing.T) {
 	s := NewServer(":0")
-	go s.Run()
+	ready := make(chan struct{})
+	go s.Run(ready)
 	defer s.Close()
-	time.Sleep(100 * time.Millisecond)
+	<-ready
 
 	c1, err := ic.Connect(s.Addr)
 	if err != nil {

--- a/project/irc/irc/server.go
+++ b/project/irc/irc/server.go
@@ -40,7 +40,9 @@ func NewServer(addr string) *Server {
 	}
 }
 
-func (s *Server) Run() error {
+// Run starts accepting connections. If ready is non-nil it will receive a
+// signal once the listener is setup and the server address updated.
+func (s *Server) Run(ready chan<- struct{}) error {
 	ln, err := net.Listen("tcp", s.Addr)
 	if err != nil {
 		return err
@@ -49,6 +51,10 @@ func (s *Server) Run() error {
 	s.Addr = ln.Addr().String()
 	Logger.Printf("IRC server listening on %s", s.Addr)
 	fmt.Printf("IRC server started on %s\n", s.Addr)
+	if ready != nil {
+		// notify callers that the server is ready to accept connections
+		ready <- struct{}{}
+	}
 	for {
 		conn, err := ln.Accept()
 		if err != nil {

--- a/project/irc/server/main.go
+++ b/project/irc/server/main.go
@@ -18,7 +18,7 @@ func main() {
 
 	addr := ":6667"
 	s := irc.NewServer(addr)
-	if err := s.Run(); err != nil {
+	if err := s.Run(nil); err != nil {
 		irc.ErrorLogger.Fatal(err)
 	}
 }


### PR DESCRIPTION
## Summary
- notify when IRC server is ready by adding a `ready` channel to `Server.Run`
- wait on readiness channel in `TestClientFlow` and example
- support nil readiness channel for normal server startup

## Testing
- `go test ./irc -v`