### PR TITLE
Fix tests by cleaning server API

### DIFF
--- a/project/irc/example/main.go
+++ b/project/irc/example/main.go
@@ -14,9 +14,8 @@ func main() {
 	irc.ErrorLogger = irc.Logger
 
 	srv := irc.NewServer(":6667")
-	ready := make(chan struct{})
 	go func() {
-		if err := srv.Run(ready); err != nil {
+		if err := srv.Run(); err != nil {
 			irc.ErrorLogger.Fatal(err)
 		}
 	}()

--- a/project/irc/irc/server.go
+++ b/project/irc/irc/server.go
@@ -59,10 +59,6 @@ func (s *Server) Run() error {
 	close(s.ready)
 	Logger.Printf("IRC server listening on %s", s.Addr)
 	fmt.Printf("IRC server started on %s\n", s.Addr)
-	if ready != nil {
-		// notify callers that the server is ready to accept connections
-		ready <- struct{}{}
-	}
 	for {
 		conn, err := ln.Accept()
 		if err != nil {

--- a/project/irc/server/main.go
+++ b/project/irc/server/main.go
@@ -18,7 +18,7 @@ func main() {
 
 	addr := ":6667"
 	s := irc.NewServer(addr)
-	if err := s.Run(nil); err != nil {
+	if err := s.Run(); err != nil {
 		irc.ErrorLogger.Fatal(err)
 	}
 }


### PR DESCRIPTION
## Summary
- remove stray `ready` channel code from `Server.Run`
- update example and server main to call `Run()` with no arguments

## Testing
- `go test ./...`