### PR TITLE
Add configurable backend server and db path

### DIFF
--- a/project/code-review/README.md
+++ b/project/code-review/README.md
@@ -19,6 +19,11 @@ cd backend
 go run ./...
 ```
 
+The server can be configured with environment variables:
+
+* `PORT` - HTTP listen address, defaults to `:8080`.
+* `DB_PATH` - SQLite database file path, defaults to `code_review.db`.
+
 Run tests with:
 
 ```bash

--- a/project/code-review/backend/main.go
+++ b/project/code-review/backend/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"log"
+	"os"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/driver/sqlite"
@@ -11,8 +13,11 @@ import (
 	"code-review/internal/models"
 )
 
-func setupDB() (*gorm.DB, error) {
-	db, err := gorm.Open(sqlite.Open("code_review.db"), &gorm.Config{})
+func setupDB(path string) (*gorm.DB, error) {
+	if path == "" {
+		path = "code_review.db"
+	}
+	db, err := gorm.Open(sqlite.Open(path), &gorm.Config{})
 	if err != nil {
 		return nil, err
 	}
@@ -23,7 +28,7 @@ func setupDB() (*gorm.DB, error) {
 }
 
 func main() {
-	db, err := setupDB()
+	db, err := setupDB(os.Getenv("DB_PATH"))
 	if err != nil {
 		log.Fatalf("failed to setup db: %v", err)
 	}
@@ -38,7 +43,14 @@ func main() {
 	router.GET("/prs/:id/comments", commentHandler.ListComments)
 	router.POST("/prs/:id/comments", commentHandler.CreateComment)
 
-	if err := router.Run(":8080"); err != nil {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = ":8080"
+	} else if !strings.HasPrefix(port, ":") {
+		port = ":" + port
+	}
+
+	if err := router.Run(port); err != nil {
 		log.Fatalf("server failed: %v", err)
 	}
 }

--- a/project/code-review/backend/main_test.go
+++ b/project/code-review/backend/main_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSetupDBCreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.db")
+	db, err := setupDB(path)
+	if err != nil {
+		t.Fatalf("setupDB: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("db.DB: %v", err)
+	}
+	sqlDB.Close()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected %s to exist: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary
- read `PORT` and `DB_PATH` env vars in backend `main.go`
- update `setupDB` to accept a path argument
- add tests verifying that `setupDB` creates the given DB
- document new configuration options

## Testing
- `go test ./...` *(fails: missing go.sum entries)*